### PR TITLE
Suspend RNG State Synchronisation

### DIFF
--- a/src/deflex.cpp
+++ b/src/deflex.cpp
@@ -78,6 +78,9 @@ SEXP deflex_strategy3 (Rcpp::Function objective,
   // PREAMBLE //
   //////////////
 
+  // Before we start, suspend RNG synchronisation:
+  Rcpp::SuspendRNGSynchronizationScope rngScope;
+
   // First, get the problem dimension:
   const int dimension = upper.size();
 


### PR DESCRIPTION
The issue was introduced by PR on Rcpp:

<https://github.com/RcppCore/Rcpp/pull/825>

It was mitigated by PR on Rcpp (to opt-out from the behaviour introduced above):

<https://github.com/RcppCore/Rcpp/pull/862>

... and demonstrated by PR on RcppDE:

<https://github.com/eddelbuettel/rcppde/pull/15>
